### PR TITLE
Made register and deploy config optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This role requires Ansible 2.4 or higher. Requirements are listed in the metadat
 | `icinga_director_user` | Yes | `admin` | Icinga Web user for API authentication.  |
 | `icinga_director_pass` | Yes | Not set | Icinga Web user password for API authentication.  |
 | `icinga_director_host_protocol` | No | `http` | Protocol used to communicate with Icinga Director - http or https.  |
+| `icinga_register_client` | No | `yes` | Register Icinga client host. Set to `no` to skip this step. |
+| `icinga_deploy_config` | No | `yes` | Trigger Icinga Director to deploy config. Set to `no` to skip this step. | 
 
 
 Example Playbook
@@ -43,3 +45,4 @@ MIT
 Author Information
 ------------------
 This role was created in 2018 by [Mykhaylo Kolesnik](http://github.com/tenequm).
+Updates by [Blue Billywig](http://github.com/bluebillywig).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,3 +18,6 @@ icinga_client_host_object:
   object_type: "object"
   imports:
     - "{{ icinga_client_import_template }}"
+
+icinga_register_client: yes
+icinga_deploy_config: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,8 @@
     url: "{{ icinga_director_url }}/host"
     user: "{{ icinga_director_user }}"
     password: "{{ icinga_director_pass }}"
-    status_code: 201,500
+    status_code: 201,422,500
+  when: icinga_register_client
 
 - name: Trigger Icinga Director to deploy config.
   uri:
@@ -39,6 +40,7 @@
     url: "{{ icinga_director_url }}/config/deploy"
     user: "{{ icinga_director_user }}"
     password: "{{ icinga_director_pass }}"
+  when: icinga_deploy_config
 
 - name: Get Icinga client ticket.
   uri:


### PR DESCRIPTION
* Register Icinga client host step can be skipped by setting `icinga_register_client: no`.
* Trigger Icinga Director to deploy config step can be skipped by setting `icinga_deploy_config: no`.
* Register Icinga client host step now access response code `422` as valid (host already registered).